### PR TITLE
changed timestamp in image build, 2020-04 -> 2021-04

### DIFF
--- a/ubuntu-20.04-amd64-efi-minimal.json
+++ b/ubuntu-20.04-amd64-efi-minimal.json
@@ -71,7 +71,7 @@
       "variables": {
         "box_basename": "ubuntu-20.04",
         "build_directory": "./builds",
-        "build_timestamp": "2020-04",
+        "build_timestamp": "2021-04",
         "cpus": "2",
         "disk_size": "10240",
         "git_revision": "__unknown_git_revision__",

--- a/ubuntu-20.04-amd64-efi.json
+++ b/ubuntu-20.04-amd64-efi.json
@@ -71,7 +71,7 @@
       "variables": {
         "box_basename": "ubuntu-20.04",
         "build_directory": "./builds",
-        "build_timestamp": "2020-04",
+        "build_timestamp": "2021-04",
         "cpus": "2",
         "disk_size": "153600",
         "git_revision": "__unknown_git_revision__",

--- a/ubuntu-20.04-amd64-minimal.json
+++ b/ubuntu-20.04-amd64-minimal.json
@@ -74,7 +74,7 @@
       "variables": {
         "box_basename": "ubuntu-20.04",
         "build_directory": "./builds",
-        "build_timestamp": "2020-04",
+        "build_timestamp": "2021-04",
         "cpus": "2",
         "disk_size": "10240",
         "git_revision": "__unknown_git_revision__",

--- a/ubuntu-20.04-amd64.json
+++ b/ubuntu-20.04-amd64.json
@@ -74,7 +74,7 @@
       "variables": {
         "box_basename": "ubuntu-20.04",
         "build_directory": "./builds",
-        "build_timestamp": "2020-04",
+        "build_timestamp": "2021-04",
         "cpus": "2",
         "disk_size": "153600",
         "git_revision": "__unknown_git_revision__",


### PR DESCRIPTION
Signed-off-by: Bernd Mueller <mueller@b1-systems.de>