### PR TITLE
Ansible-lint: Refactor rules and noqas

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -4,25 +4,8 @@ exclude_paths:
 use_default_rules: true
 rulesdir:
   - ./.ansible-lint-rules/
-mock_roles:
-  - resolvconf
-  - repository
-  - chrony
-  - systohc
-  - configfs
-  - packages
-  - sysctl
-  - services
-  - motd
-  - hddtemp
-  - rng
-  - cleanup
 skip_list:
-  - parser-error  # AnsibleParserError.
-  - var-spacing  # Variables should have spaces before and after: {{ var_name }}.
-  - fqcn-builtins
   - yaml
-  - fqcn[keyword]
 # DO NOT DELETE THE WARNLIST! It is required for our custom rules!
 # If this isn't there our custom rules will only through a warning and wont generate a failure!:
 warn_list:

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,0 +1,9 @@
+---
+collections:
+  - name: https://github.com/osism/ansible-collection-commons.git
+    type: git
+    version: main
+
+  - name: https://github.com/osism/ansible-collection-services.git
+    type: git
+    version: main

--- a/scripts/provision/cleanup-Debian.yml
+++ b/scripts/provision/cleanup-Debian.yml
@@ -1,13 +1,14 @@
 ---
 - name: Set python3 as default
-  ansible.builtin.command: update-alternatives --install /usr/bin/python python /usr/bin/python3 1  # noqa 301
   become: true
+  ansible.builtin.command: update-alternatives --install /usr/bin/python python /usr/bin/python3 1
+  changed_when: true
 
 # NOTE: This must be the last task. It will uninstall Ansible.
 - name: Purge python2 environment - {{ ansible_os_family }}
+  become: true
   ansible.builtin.apt:
     name: python
     state: absent
     autoremove: true
     purge: true
-  become: true

--- a/scripts/provision/node.yml
+++ b/scripts/provision/node.yml
@@ -7,13 +7,9 @@
   vars:
     ansible_python_interpreter: /usr/bin/python3
 
-  collections:
-    - osism.commons
-    - osism.services
-
   roles:
-    - role: resolvconf
-    - role: repository
+    - role: osism.commons.resolvconf
+    - role: osism.commons.repository
 
 - name: Bootstrap node - pt. 2
   hosts: localhost
@@ -49,18 +45,14 @@
     operator_authorized_keys:
       - "{{ lookup('file', '/home/install/.ssh/id_rsa.pub') }}"
 
-  collections:
-    - osism.commons
-    - osism.services
-
   roles:
-    - role: chrony
-    - role: systohc
-    - role: configfs
-    - role: packages
-    - role: sysctl
-    - role: services
-    - role: motd
-    - role: hddtemp
-    - role: rng
-    - role: cleanup
+    - role: osism.services.chrony
+    - role: osism.commons.systohc
+    - role: osism.commons.configfs
+    - role: osism.commons.packages
+    - role: osism.commons.sysctl
+    - role: osism.commons.services
+    - role: osism.commons.motd
+    - role: osism.services.hddtemp
+    - role: osism.services.rng
+    - role: osism.commons.cleanup


### PR DESCRIPTION
- Rework outdated noqas
- Rework become position like described in the styleguide
- Delete ansible-lint rules which are no longer needed and rework at some points the code.
- Partly osism/issues#496

Signed-off-by: Ramona Beermann <ramona.beermann@osism.tech>
